### PR TITLE
Nextra now uses the `latest` version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "homepage": "https://github.com/shuding/nextra-docs-template#readme",
   "dependencies": {
     "next": "^13.0.6",
-    "nextra": "2.0.1",
-    "nextra-theme-docs": "2.0.1",
+    "nextra": "latest",
+    "nextra-theme-docs": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
Helps fix the issue where Nextra users complain about v2.0.1 problems

Reference: [here](https://github.com/shuding/nextra/issues/1447)